### PR TITLE
fix: correct implementation of indexOf

### DIFF
--- a/app/src/main/java/fi/razerman/youtube/litho/LithoAdRemoval.java
+++ b/app/src/main/java/fi/razerman/youtube/litho/LithoAdRemoval.java
@@ -188,14 +188,17 @@ public class LithoAdRemoval {
             return 0;
         }
 
-        int i = 0;
-        while (i < array.length - target.length + 1 ){
+        for (int i = 0; i < array.length - target.length + 1; i++) {
+            boolean targetFound = true;
             for (int j = 0; j < target.length; j++) {
                 if (array[i+j] != target[j]) {
+                    targetFound = false;
                     break;
                 }
             }
-            return i;
+            if (targetFound) {
+                return i;
+            }
         }
         return -1;
     }


### PR DESCRIPTION
Not sure if this is even useful, but I noticed that the reimplementation of LithoAdRemoval.indexOf never increments the index for the outer loop, causing an infinite loop.